### PR TITLE
v0.1.41

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,6 +1,10 @@
 ### Version History
 
 
+#### v0.1.41
+- fixes saving project (*.mpr) if the project was loaded with an existing spectrogram
+
+
 #### v0.1.40
 - Meico update to v0.11.13.
 

--- a/src/mpmToolbox/Main.java
+++ b/src/mpmToolbox/Main.java
@@ -13,7 +13,7 @@ import java.io.IOException;
  * @author Axel Berndt
  */
 public class Main {
-    public static final String version = "0.1.40";
+    public static final String version = "0.1.41";
 
     public static void main(String[] args) {
         // read the application settings from file

--- a/src/mpmToolbox/projectData/audio/SpectrogramImage.java
+++ b/src/mpmToolbox/projectData/audio/SpectrogramImage.java
@@ -152,6 +152,8 @@ public class SpectrogramImage extends BufferedImage {
         } else
             windowFunction = new WindowFunction.Hamming(windowLength);  // default
 
-        return new SpectrogramImage(image, windowFunction, hopSize, minFrequency, maxFrequency, binsPerSemitone, normalize);
+        SpectrogramImage specImg = new SpectrogramImage(image, windowFunction, hopSize, minFrequency, maxFrequency, binsPerSemitone, normalize);
+        specImg.setFile(imageFile);
+        return specImg;
     }
 }


### PR DESCRIPTION
- fixes saving project (*.mpr) if the project was loaded with an existing spectrogram

(image"File" is needed for saving, thereby setting ("setFile") it if spectrogramImage is loaded)